### PR TITLE
Fix README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Third Party Checker
 
-Tool for crawling a website and checking for third party requests using puppeteer.
+Tool for crawling websites and checking for third party requests using Puppeteer.
 
 ## Installation
 
@@ -11,8 +11,9 @@ npm install
 ```
 
 ## Usage
-- Create a `sites.yml` with a list of all sites.
+- Create a `sites.yml` with a list of sites.
 - Make the file executable `chmod +x third-party-checker.js`.
+- Create a `report` folder.
 - Run `./third-party-checker.js sites.yml`.
 
 ## Sites.yml


### PR DESCRIPTION
The folder `report/` needs to be created before running the script to prevent an `no such file or directory` error from being thrown.